### PR TITLE
fix(card-pack-selector): optimize UX

### DIFF
--- a/src/components/CardPackSelector.vue
+++ b/src/components/CardPackSelector.vue
@@ -122,7 +122,12 @@ const totalSelectedWhiteCardCount = computed(() => {
 <template>
   <div class="flex flex-row gap-4 items-center">
     <div class="grow">
-      <template v-if="selectedCardPackCount > 0">
+      <template
+        v-if="
+          (submittedSelectedPacks && submittedSelectedPacks.length > 0) ||
+          (dialogOpen && selectedCardPackCount > 0)
+        "
+      >
         {{ selectedCardPackCount }} pack(s) selected. That's
         {{ totalSelectedWhiteCardCount }} white cards and
         {{ totalSelectedBlackCardCount }} black cards.

--- a/src/components/CardPackSelector.vue
+++ b/src/components/CardPackSelector.vue
@@ -222,7 +222,9 @@ const totalSelectedWhiteCardCount = computed(() => {
               {{ totalSelectedBlackCardCount }} black cards.
             </template>
             <template v-else> No pack selected </template>
-            <button @click="submit">Finish</button>
+            <button @click="submit" class="bg-blue-600 hover:bg-blue-700">
+              Done!
+            </button>
           </div>
         </div>
       </DialogPanel>


### PR DESCRIPTION
This pull request includes changes to improve the user interface and functionality of the `CardPackSelector` component in the `src/components/CardPackSelector.vue` file. Specifically:

* When the user leaves the selector without actually submitting any packs, previously the home page will show the amount of *non-submitted* packs and cards. This might cause confusion as the user cannot start the game until they enter the selection dialog again and click the "submit" button.
  <img width="764" alt="image" src="https://github.com/user-attachments/assets/a3656b07-f1f7-4412-a984-20374d495490" />
  This behavior has been changed so that when the dialog is not open, we will additionally check whether the selected packs are actually submitted.
* Changed the button text from "Finish" to "Done!" and added styling classes `bg-blue-600` and `hover:bg-blue-700` for better visual feedback.
  <img width="193" alt="image" src="https://github.com/user-attachments/assets/d20ab206-3031-45ab-97e7-9cb056ced759" />
